### PR TITLE
stagefright: Disable spammy debugging

### DIFF
--- a/media/libstagefright/Android.mk
+++ b/media/libstagefright/Android.mk
@@ -154,7 +154,7 @@ LOCAL_SANITIZE := unsigned-integer-overflow signed-integer-overflow
 # FFMPEG plugin
 LOCAL_C_INCLUDES += $(TOP)/external/stagefright-plugins/include
 
-LOCAL_CFLAGS += -DLOG_NDEBUG=0
+#LOCAL_CFLAGS += -DLOG_NDEBUG=0
 LOCAL_MODULE:= libstagefright
 
 LOCAL_MODULE_TAGS := optional


### PR DESCRIPTION
- Was left on in the FFMPEG commit, so removing it.

Change-Id: I158f5642289716d37e131fd1bbafc33582489439
